### PR TITLE
Option to disable plugin entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Which will result in something like this:
 <a href="http://kenya-politicians.writeinpublic.com/en/write/who/?person_id=person/123abc">Write to Bob on WriteInPublic!</a>
 ```
 
+If your WriteInPublic site is still in testing mode you might want to disable this plugin temporarily so the link doesn't show up on the site. You can do this with the `disabled` option:
+
+```yaml
+writeinpublic:
+  subdomain: kenya-politicians
+  disabled: true
+```
+
+With this set the plugin won't render anything.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/jekyll/writeinpublic.rb
+++ b/lib/jekyll/writeinpublic.rb
@@ -14,6 +14,7 @@ module Jekyll
         site = context.registers[:site]
         writeinpublic = site.config['writeinpublic']
         return unless writeinpublic && writeinpublic.key?('subdomain')
+        return if writeinpublic['disabled']
         person_id = context[@markup]
         %(<a href="#{link(writeinpublic['subdomain'], person_id)}">#{super}</a>)
       end

--- a/test/jekyll/writeinpublic_test.rb
+++ b/test/jekyll/writeinpublic_test.rb
@@ -5,13 +5,28 @@ class Jekyll::WriteinpublicTest < Minitest::Test
     refute_nil ::Jekyll::Writeinpublic::VERSION
   end
 
+  def site
+    @site ||= Jekyll::Site.new(Jekyll.configuration)
+  end
+
+  def template
+    @template ||= '{% writeinpublic_link person.id %}Write to {{ person.name }}{% endwriteinpublic_link %}'
+  end
+
+  def tmpl
+    @tmpl ||= Liquid::Template.parse(template).tap do |t|
+      t.registers[:site] = site
+    end
+  end
+
   def test_rendering_tag
-    site = Jekyll::Site.new(Jekyll.configuration)
     site.config['writeinpublic'] = { 'subdomain' => 'testing' }
-    template = '{% writeinpublic_link person.id %}Write to {{ person.name }}{% endwriteinpublic_link %}'
-    tmpl = Liquid::Template.parse(template)
-    tmpl.registers[:site] = site
     expected = %(<a href="http://testing.writeinpublic.com/en/write/who/?person_id=person/123abc">Write to Bob</a>)
     assert_equal expected, tmpl.render('person' => { 'id' => '123abc', 'name' => 'Bob' })
+  end
+
+  def test_renders_nothing_when_disabled
+    site.config['writeinpublic'] = { 'subdomain' => 'testing', 'disabled' => true }
+    assert_equal '', tmpl.render('person' => { 'id' => '123abc', 'name' => 'Bob' })
   end
 end


### PR DESCRIPTION
If your WriteInPublic site isn't ready to be used yet you might need to
temporarily disable this plugin using a config option. This change adds
a 'disabled' option which when set causes the plugin to render nothing.

For https://github.com/mysociety/kuvakazim/issues/24
